### PR TITLE
Port from std to alloc, excluding stdout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,13 @@ repository = "https://github.com/cigna/tap-rust"
 readme = "README.md"
 
 [dependencies]
+
+[features]
+default = ["std"]
+
+# Provide all features. Requires a dependency on the Rust standard library.
+std = []
+
+# Provide everything except printing to stdout. Uses `alloc`, which is a subset
+# of std but may be enabled without depending on all of std.
+alloc = []

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ not ok 2 Curry Noodle
 # Flower
 ```
 
+### Use with `alloc` only (`#[no_std]`)
+
+To use this crate with alloc in `#[no_std]`, use:
+  testanything = { version = "*", default-features = false, features = ["alloc"] }
+
 ## Testing
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ not ok 2 Curry Noodle
 ### Use with `alloc` only (`#[no_std]`)
 
 To use this crate with alloc in `#[no_std]`, use:
-  testanything = { version = "*", default-features = false, features = ["alloc"] }
+
+`testanything = { version = "*", default-features = false, features = ["alloc"] }`
 
 ## Testing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,11 @@
 //!
 //!
 
+// Support using TAP without the standard library
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
+
 /// Global constant for the "ok"
 const OK_SYMBOL: &str = "ok";
 /// Global constant for the "not ok"
@@ -80,5 +85,6 @@ pub mod tap_suite_builder;
 pub mod tap_test;
 /// `TapTestBuilder` -- Helper for creating a `TapTest` using the builder pattern.
 pub mod tap_test_builder;
+#[cfg(feature = "std")]
 /// `TapWriter` -- For writing TAP streams incrementally
 pub mod tap_writer;

--- a/src/tap_suite.rs
+++ b/src/tap_suite.rs
@@ -1,6 +1,9 @@
-use crate::tap_test::TapTest;
-
+#[cfg(feature = "alloc")]
+use alloc::{format, string::String, vec, vec::Vec};
+#[cfg(feature = "std")]
 use std::io::Write;
+
+use crate::tap_test::TapTest;
 
 /// Represents a collection of TAP tests (`TapTest`) which can be rendered into a (text) TAP stream. This orchestrates that rendering.
 #[derive(Debug, Clone)]
@@ -26,11 +29,14 @@ impl TapSuite {
 
         all_lines
     }
+}
 
+#[cfg(feature = "std")]
+impl TapSuite {
     /// Emit TAP stream to the provided sink, which must be `Write`.
     pub fn print<T: Write>(&self, mut sink: T) -> Result<String, String> {
         let output = self.lines().join("\n");
-        match sink.write_all(output.as_bytes()) {
+        match write!(&mut sink, "{}", output) {
             Ok(_) => Result::Ok(output),
             Err(reason) => Result::Err(reason.to_string()),
         }

--- a/src/tap_suite_builder.rs
+++ b/src/tap_suite_builder.rs
@@ -1,3 +1,11 @@
+#[cfg(feature = "alloc")]
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use core::option::Option;
+
 use crate::tap_suite::TapSuite;
 use crate::tap_test::TapTest;
 

--- a/src/tap_test.rs
+++ b/src/tap_test.rs
@@ -1,3 +1,11 @@
+#[cfg(feature = "alloc")]
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use core::fmt::Write;
+
 use crate::{NOT_OK_SYMBOL, OK_SYMBOL};
 
 /// A test, a collection of which (a `TapSuite`) will be rendered into a TAP text stream. A `TapTest` knows how to render itself.
@@ -25,7 +33,12 @@ impl TapTest {
 
     /// Produce a properly-formatted TAP line. This excludes diagnostics.
     pub fn status_line(&self, test_number: i64) -> String {
-        format!("{} {} {}", self.ok_string(), test_number, self.name)
+        let ok_string = self.ok_string();
+        let test_number_string = test_number.to_string();
+        let mut buf =
+            String::with_capacity(ok_string.len() + test_number_string.len() + self.name.len());
+        write!(&mut buf, "{} {} {}", ok_string, test_number, self.name).unwrap();
+        buf
     }
 
     /// Produce all lines (inclusive of diagnostics) representing this test. This is the money, right here.
@@ -46,16 +59,22 @@ impl TapTest {
 
     /// Diagnostics should begin with a # mark
     pub fn format_diagnostics(&self, line: &str) -> String {
-        format!("# {}", line)
+        let mut buf = String::with_capacity(line.len() + 2);
+        write!(&mut buf, "# {}", line).unwrap();
+        buf
     }
 }
 
 impl From<TapTest> for String {
     fn from(tap_test: TapTest) -> Self {
-        format!(
+        let mut buf = String::new();
+        write!(
+            &mut buf,
             "TapTest(name: {}, passed: {}, diagnostics: {:?})",
             tap_test.name, tap_test.passed, tap_test.diagnostics
         )
+        .unwrap();
+        buf
     }
 }
 

--- a/src/tap_test_builder.rs
+++ b/src/tap_test_builder.rs
@@ -1,3 +1,10 @@
+#[cfg(feature = "alloc")]
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{default::Default, option::Option};
+
 use crate::tap_test::TapTest;
 
 /// Coordinator for construction of `TapTest` objects using the builder pattern.


### PR DESCRIPTION
I thought this was useful for testing on bare metal RISC-V, so I ported it to work without std using alloc only. Anything to do with printing to stdout was left out of the `alloc` version, since that's strictly a part of the standard library.

Level of testing:

- `cargo test` passes as in original
- the 'alloc' version checks out with `cargo check --no-default-features --features=alloc`

